### PR TITLE
doc: use requirements.txt to install Python dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ After that, all you need to do is hook up the push buttons to the Raspberry Pi. 
 
 ### Setting up the code
 
-To get the code working, you can first clone our repository. Next, you need to install Python dependencies
+To get the code working, you can first clone our repository. Next, you need to install Python dependencies :
 
 ```bash
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ After that, all you need to do is hook up the push buttons to the Raspberry Pi. 
 
 ### Setting up the code
 
-To get the code working, you can first clone our repository. We require a few dependencies: PIL, subprocess, and Flask. To get those working, just run `pip install dependency`.
+To get the code working, you can first clone our repository. Next, you need to install Python dependencies
+
+```bash
+pip install -r requirements.txt
+```
 
 To install matplotlib, run `sudo apt-get install libpulse-dev` and `sudo apt-get install python-dev` before attempting to install `matplotlib` with `sudo apt-get install python-matplotlib`, as instructed by [this Stack Overflow response](https://stackoverflow.com/questions/43613666/pip-install-matplotlib-fails-on-raspbian-jessie-4-4).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+Pillow
+pydub


### PR DESCRIPTION
Use `requirements.txt` is easier for newcomers to install Python dependencies.